### PR TITLE
feat: init solution with 2 projects

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/projectSettingsUpdater.xml
+/.idea.PracticeGamestore.iml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/.gitignore
+++ b/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.PracticeGamestore.iml
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/encodings.xml
+++ b/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/indexLayout.xml
+++ b/PracticeGamestore/.idea/.idea.PracticeGamestore/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Entities/Platform.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Entities/Platform.cs
@@ -1,0 +1,8 @@
+﻿namespace PracticeGamestore.DataAccess.Entities;
+
+public class Platform
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+}

--- a/PracticeGamestore/PracticeGamestore.DataAccess/PracticeGamestore.DataAccess.csproj
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/PracticeGamestore.DataAccess.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <None Remove="Properties\launchSettings.json" />
+    </ItemGroup>
+
+</Project>

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/PracticeGamestore.Infrastructure.csproj
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/PracticeGamestore.Infrastructure.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RootNamespace>PracticeGamestore</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../PracticeGamestore.DataAccess/PracticeGamestore.DataAccess.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.13"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+    </ItemGroup>
+
+</Project>

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/PracticeGamestore.http
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/PracticeGamestore.http
@@ -1,0 +1,6 @@
+@PracticeGamestore_HostAddress = http://localhost:5221
+
+GET {{PracticeGamestore_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/Program.cs
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/Program.cs
@@ -1,0 +1,44 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+    {
+        var forecast = Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                (
+                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                    Random.Shared.Next(-20, 55),
+                    summaries[Random.Shared.Next(summaries.Length)]
+                ))
+            .ToArray();
+        return forecast;
+    })
+    .WithName("GetWeatherForecast")
+    .WithOpenApi();
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/Properties/launchSettings.json
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:30359",
+      "sslPort": 44341
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5221",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7067;http://localhost:5221",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/appsettings.Development.json
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/PracticeGamestore/PracticeGamestore.Infrastructure/appsettings.json
+++ b/PracticeGamestore/PracticeGamestore.Infrastructure/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/PracticeGamestore/PracticeGamestore.sln
+++ b/PracticeGamestore/PracticeGamestore.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PracticeGamestore.Infrastructure", "PracticeGamestore.Infrastructure\PracticeGamestore.Infrastructure.csproj", "{4D746D23-E148-4682-9B9F-C7282766C4F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PracticeGamestore.DataAccess", "PracticeGamestore.DataAccess\PracticeGamestore.DataAccess.csproj", "{7A93E1FF-127B-4B77-81B7-2D0B16764AB2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4D746D23-E148-4682-9B9F-C7282766C4F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D746D23-E148-4682-9B9F-C7282766C4F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D746D23-E148-4682-9B9F-C7282766C4F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D746D23-E148-4682-9B9F-C7282766C4F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A93E1FF-127B-4B77-81B7-2D0B16764AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A93E1FF-127B-4B77-81B7-2D0B16764AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A93E1FF-127B-4B77-81B7-2D0B16764AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A93E1FF-127B-4B77-81B7-2D0B16764AB2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/PracticeGamestore/global.json
+++ b/PracticeGamestore/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This pull request sets up the foundational structure for the `PracticeGamestore` project, including solution configuration, project files, and initial code implementations. The changes include adding a new `Platform` entity, configuring the `DataAccess` and `Infrastructure` projects, and setting up a basic API with Swagger support.

### Project Setup and Configuration:

* Added a solution file (`PracticeGamestore.sln`) to manage the `DataAccess` and `Infrastructure` projects.
* Created a `global.json` file to specify the .NET SDK version (8.0.0) and configuration settings.

### Data Access Layer:

* Introduced a new `Platform` entity with `Id`, `Name`, and `Description` properties in the `PracticeGamestore.DataAccess` project.
* Configured the `PracticeGamestore.DataAccess` project with .NET 8.0, nullable reference types, and implicit usings enabled.

### Infrastructure Layer:

* Configured the `PracticeGamestore.Infrastructure` project using WEB Api template with .NET 8.0, Swagger/OpenAPI support, and a project reference to the `DataAccess` project.