### PR TITLE
feat: init test project

### DIFF
--- a/PracticeGamestore/PracticeGamestore.Tests/PracticeGamestore.Tests.csproj
+++ b/PracticeGamestore/PracticeGamestore.Tests/PracticeGamestore.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>PracticeGamestore.API.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Moq" Version="4.20.72" />
+      <PackageReference Include="NUnit" Version="4.3.2" />
+      <PackageReference Include="xunit" Version="2.9.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\PracticeGamestore.API/PracticeGamestore.API.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="TestSuiteAssembly" />
+    </ItemGroup>
+
+</Project>

--- a/PracticeGamestore/PracticeGamestore.sln
+++ b/PracticeGamestore/PracticeGamestore.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PracticeGamestore.DataAcces
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PracticeGamestore.Business", "PracticeGamestore.Business\PracticeGamestore.Business.csproj", "{CF0E404F-5475-48D0-AD7C-8B229904FAF1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PracticeGamestore.Tests", "PracticeGamestore.Tests\PracticeGamestore.Tests.csproj", "{24D423E5-9751-470D-B35C-F84476EF6B81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{CF0E404F-5475-48D0-AD7C-8B229904FAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF0E404F-5475-48D0-AD7C-8B229904FAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF0E404F-5475-48D0-AD7C-8B229904FAF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24D423E5-9751-470D-B35C-F84476EF6B81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24D423E5-9751-470D-B35C-F84476EF6B81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24D423E5-9751-470D-B35C-F84476EF6B81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24D423E5-9751-470D-B35C-F84476EF6B81}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This pull request introduces a new test project for the `PracticeGamestore` solution, setting up the necessary configurations and dependencies to support unit testing. The changes include adding a new `.csproj` file for the test project, updating the solution file to include the test project, and configuring build settings for the test project.

### Addition of a new test project:

* [`PracticeGamestore/PracticeGamestore.Tests/PracticeGamestore.Tests.csproj`](diffhunk://#diff-1188e689be366bcec15a14501b2303a32f6add278e09b0480555eda1e1b1aa0bR1-R31): Added a new `.csproj` file for the `PracticeGamestore.Tests` project, targeting `.NET 8.0`. It includes dependencies on `Moq`, `NUnit`, and `xUnit`, and references the main `PracticeGamestore.API` project. The project is marked as a test project and includes `InternalsVisibleTo` for test suite access.

### Solution file updates:

* [`PracticeGamestore/PracticeGamestore.sln`](diffhunk://#diff-69652c135f78b87210b4318f7baacac89a40af5ac23c458f288d1aa3ebcf5981R9-R10): Added the `PracticeGamestore.Tests` project to the solution, including its GUID and path.
* [`PracticeGamestore/PracticeGamestore.sln`](diffhunk://#diff-69652c135f78b87210b4318f7baacac89a40af5ac23c458f288d1aa3ebcf5981R29-R32): Configured build settings for the `PracticeGamestore.Tests` project, ensuring it supports both `Debug` and `Release` configurations.