### PR TITLE
Get games by genre

### DIFF
--- a/PracticeGamestore/PracticeGamestore.API/Controllers/GenreController.cs
+++ b/PracticeGamestore/PracticeGamestore.API/Controllers/GenreController.cs
@@ -52,7 +52,7 @@ public class GenreController(IGenreService genreService) : ControllerBase
     [HttpGet("{id:guid}/games")]
     public async Task<IActionResult> GetGamesByGenre([FromRoute] Guid id)
     {
-        var games = await genreService.GetGamesByGenreAsync(id);
+        var games = await genreService.GetGames(id);
         return games is null
             ? NotFound($"Genre with id {id} was not found.")
             : Ok(games.Select(g => g.MapToGameModel()));

--- a/PracticeGamestore/PracticeGamestore.API/Controllers/GenreController.cs
+++ b/PracticeGamestore/PracticeGamestore.API/Controllers/GenreController.cs
@@ -16,7 +16,7 @@ public class GenreController(IGenreService genreService) : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    public async Task<IActionResult> GetById(Guid id)
+    public async Task<IActionResult> GetById([FromRoute] Guid id)
     {
         var genre = await genreService.GetByIdAsync(id);
         return genre is null
@@ -34,7 +34,7 @@ public class GenreController(IGenreService genreService) : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<IActionResult> Update(Guid id, [FromBody] GenreRequestModel model)
+    public async Task<IActionResult> Update([FromRoute] Guid id, [FromBody] GenreRequestModel model)
     {
         var isUpdated = await genreService.UpdateAsync(id, model.MapToGenreDto());
         return isUpdated 
@@ -47,5 +47,14 @@ public class GenreController(IGenreService genreService) : ControllerBase
     {
         await genreService.DeleteAsync(id);
         return NoContent();
+    }
+
+    [HttpGet("{id:guid}/games")]
+    public async Task<IActionResult> GetGamesByGenre([FromRoute] Guid id)
+    {
+        var games = await genreService.GetGamesByGenreAsync(id);
+        return games is null
+            ? NotFound($"Genre with id {id} was not found.")
+            : Ok(games.Select(g => g.MapToGameModel()));
     }
 }

--- a/PracticeGamestore/PracticeGamestore.Business/Services/Genre/GenreService.cs
+++ b/PracticeGamestore/PracticeGamestore.Business/Services/Genre/GenreService.cs
@@ -1,11 +1,12 @@
 using PracticeGamestore.Business.DataTransferObjects;
 using PracticeGamestore.Business.Mappers;
+using PracticeGamestore.DataAccess.Repositories.Game;
 using PracticeGamestore.DataAccess.Repositories.Genre;
 using PracticeGamestore.DataAccess.UnitOfWork;
 
 namespace PracticeGamestore.Business.Services.Genre;
 
-public class GenreService(IGenreRepository genreRepository, IUnitOfWork unitOfWork) : IGenreService
+public class GenreService(IGenreRepository genreRepository, IGameRepository gameRepository, IUnitOfWork unitOfWork) : IGenreService
 {
     public async Task<IEnumerable<GenreDto>> GetAllAsync()
     {
@@ -44,5 +45,14 @@ public class GenreService(IGenreRepository genreRepository, IUnitOfWork unitOfWo
     {
         await genreRepository.DeleteAsync(id);
         await unitOfWork.SaveChangesAsync();
+    }
+
+    public async Task<IEnumerable<GameResponseDto>?> GetGamesByGenreAsync(Guid id)
+    {
+        var genreExists = await genreRepository.ExistsAsync(id);
+        if (!genreExists) return null;
+        var genreChildrenIds = await genreRepository.GetGenreChildrenIdsAsync(id);
+        var games = await gameRepository.GetByGenreAndItsChildrenAsync(genreChildrenIds);
+        return games.Select(g => g.MapToGameDto());
     }
 }

--- a/PracticeGamestore/PracticeGamestore.Business/Services/Genre/GenreService.cs
+++ b/PracticeGamestore/PracticeGamestore.Business/Services/Genre/GenreService.cs
@@ -47,7 +47,7 @@ public class GenreService(IGenreRepository genreRepository, IGameRepository game
         await unitOfWork.SaveChangesAsync();
     }
 
-    public async Task<IEnumerable<GameResponseDto>?> GetGamesByGenreAsync(Guid id)
+    public async Task<IEnumerable<GameResponseDto>?> GetGames(Guid id)
     {
         var genreExists = await genreRepository.ExistsAsync(id);
         if (!genreExists) return null;

--- a/PracticeGamestore/PracticeGamestore.Business/Services/Genre/IGenreService.cs
+++ b/PracticeGamestore/PracticeGamestore.Business/Services/Genre/IGenreService.cs
@@ -9,4 +9,5 @@ public interface IGenreService
     Task<Guid?> CreateAsync(GenreDto dto);
     Task<bool> UpdateAsync(Guid id, GenreDto dto);
     Task DeleteAsync(Guid id);
+    Task<IEnumerable<GameResponseDto>?> GetGamesByGenreAsync(Guid id);
 }

--- a/PracticeGamestore/PracticeGamestore.Business/Services/Genre/IGenreService.cs
+++ b/PracticeGamestore/PracticeGamestore.Business/Services/Genre/IGenreService.cs
@@ -9,5 +9,5 @@ public interface IGenreService
     Task<Guid?> CreateAsync(GenreDto dto);
     Task<bool> UpdateAsync(Guid id, GenreDto dto);
     Task DeleteAsync(Guid id);
-    Task<IEnumerable<GameResponseDto>?> GetGamesByGenreAsync(Guid id);
+    Task<IEnumerable<GameResponseDto>?> GetGames(Guid id);
 }

--- a/PracticeGamestore/PracticeGamestore.Business/Services/Publisher/PublisherService.cs
+++ b/PracticeGamestore/PracticeGamestore.Business/Services/Publisher/PublisherService.cs
@@ -33,6 +33,7 @@ public class PublisherService(IPublisherRepository publisherRepository, IGameRep
         if (existingPublisher is null) return false;
         var updatedPublisher = dto.MapToPublisherEntity();
         updatedPublisher.Id = id;
+        publisherRepository.Update(updatedPublisher);
         var changes = await unitOfWork.SaveChangesAsync();
         return changes > 0;
     }
@@ -45,8 +46,8 @@ public class PublisherService(IPublisherRepository publisherRepository, IGameRep
 
     public async Task<IEnumerable<GameResponseDto>?> GetGamesAsync(Guid id)
     {
-        var publisher = await publisherRepository.GetByIdAsync(id);
-        if (publisher is null) return null;
+        var publisherExists = await publisherRepository.ExistsAsync(id);
+        if (!publisherExists) return null;
         var games = await gameRepository.GetByPublisherIdAsync(id);
         return games.Select(g => g.MapToGameDto());
     }

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Game/GameRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Game/GameRepository.cs
@@ -117,6 +117,16 @@ public class GameRepository(GamestoreDbContext context) : IGameRepository
         return await _gamesNoTracking.Where(g => g.PublisherId == id).ToListAsync();
     }
 
+    public async Task<IEnumerable<Entities.Game>> GetByGenreAndItsChildrenAsync(List<Guid> ids)
+    {
+        return await _gamesNoTracking.Where(g => g.GameGenres.Any(gg => ids.Contains(gg.GameId))).ToListAsync();
+    }
+
+    public async Task<IEnumerable<Entities.Game>> GetByGenreAsync(Guid id)
+    {
+        return await _gamesNoTracking.Where(g => g.GameGenres.Any(gg => gg.GenreId == id || gg.Genre.ParentId == id)).ToListAsync();
+    }
+
     private async Task AddPlatformsAsync(Guid gameId, IEnumerable<Guid> platformIds)
     {
         var gamePlatforms = platformIds.Select(id => new GamePlatform

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Game/IGameRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Game/IGameRepository.cs
@@ -11,4 +11,5 @@ public interface IGameRepository
     Task<Guid> CreateAsync(Entities.Game game, List<Guid> genreIds, List<Guid> platformIds);
     Task UpdateAsync(Entities.Game game, List<Guid> genreIds, List<Guid> platformIds);
     Task<IEnumerable<Entities.Game>> GetByPublisherIdAsync(Guid id);
+    Task<IEnumerable<Entities.Game>> GetByGenreAndItsChildrenAsync(List<Guid> ids);
 }

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Genre/GenreRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Genre/GenreRepository.cs
@@ -36,4 +36,24 @@ public class GenreRepository(GamestoreDbContext context) : IGenreRepository
             context.Genres.Remove(genre);
         }
     }
+
+    public Task<bool> ExistsAsync(Guid id)
+    {
+        return _genresNoTracking.AnyAsync(g => g.Id == id);
+    }
+    
+    public async Task<List<Guid>> GetGenreChildrenIdsAsync(Guid id)
+    {
+        return await context.Database
+            .SqlQuery<Guid>($@"
+                WITH children AS (
+                    SELECT id FROM genres
+                    WHERE id = {id}
+                    UNION ALL
+                    SELECT g.id FROM genres g
+                    JOIN children c ON g.parent_id = c.id
+                 )
+                SELECT id FROM children")
+            .ToListAsync();
+    }
 }

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Genre/IGenreRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Genre/IGenreRepository.cs
@@ -7,4 +7,6 @@ public interface IGenreRepository
     Task<Guid> CreateAsync(Entities.Genre genre);
     void Update(Entities.Genre genre);
     Task DeleteAsync(Guid id);
+    Task<bool> ExistsAsync(Guid id);
+    Task<List<Guid>> GetGenreChildrenIdsAsync(Guid id);
 }

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Publisher/IPublisherRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Publisher/IPublisherRepository.cs
@@ -7,4 +7,5 @@ public interface IPublisherRepository
     Task<Guid> CreateAsync(Entities.Publisher publisher);
     void Update(Entities.Publisher publisher);
     Task DeleteAsync(Guid id);
+    Task<bool> ExistsAsync(Guid id);
 }

--- a/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Publisher/PublisherRepository.cs
+++ b/PracticeGamestore/PracticeGamestore.DataAccess/Repositories/Publisher/PublisherRepository.cs
@@ -32,4 +32,9 @@ public class PublisherRepository(GamestoreDbContext context) : IPublisherReposit
         var publisher = await context.Publishers.FindAsync(id);
         if (publisher is not null) context.Publishers.Remove(publisher);
     }
+
+    public Task<bool> ExistsAsync(Guid id)
+    {
+        return _publisherNoTracking.AnyAsync(p => p.Id == id);
+    }
 }

--- a/PracticeGamestore/PracticeGamestore.Tests/TestData/Genre.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/TestData/Genre.cs
@@ -4,18 +4,67 @@ public class Genre
 {
     public static List<DataAccess.Entities.Genre> GenerateGenreEntities()
     {
-        return new ()
+        var strategyId = Guid.NewGuid();
+        var sportsId = Guid.NewGuid();
+        var rpgId = Guid.NewGuid();
+        var racingId = Guid.NewGuid();
+        var actionGenre = GenerateActionGenre();
+
+        return new()
         {
-            new() { Id = Guid.NewGuid(), Name = "Action" },
-            new() { Id = Guid.NewGuid(), Name = "FPS" },
-            new() { Id = Guid.NewGuid(), Name = "RPG" },
-            new() { Id = Guid.NewGuid(), Name = "Strategy" },
-            new() { Id = Guid.NewGuid(), Name = "Adventure" },
-            new() { Id = Guid.NewGuid(), Name = "Racing" },
-            new() { Id = Guid.NewGuid(), Name = "Sports" },
-            new() { Id = Guid.NewGuid(), Name = "Simulation" },
-            new() { Id = Guid.NewGuid(), Name = "Horror" },
-            new() { Id = Guid.NewGuid(), Name = "Puzzle" }
+            actionGenre,
+            new() { Id = strategyId, Name = "Strategy", Description = "Strategic thinking and planning games" },
+            new() { Id = sportsId, Name = "Sports", Description = "Sports simulation and arcade games" },
+            new() { Id = rpgId, Name = "RPG", Description = "Role-playing games" },
+            new() { Id = racingId, Name = "Racing", Description = "Racing and driving games" },
+            new() { Id = Guid.NewGuid(), Name = "Adventure", Description = "Story-driven adventure games" },
+            new() { Id = Guid.NewGuid(), Name = "Simulation", Description = "Life and business simulation games" },
+            new() { Id = Guid.NewGuid(), Name = "Horror", Description = "Scary and thriller games" },
+            new() { Id = Guid.NewGuid(), Name = "Puzzle", Description = "Brain teasers and logic games" },
+            new() { Id = Guid.NewGuid(), Name = "FPS", Description = "First-person shooter", ParentId = actionGenre.Id },
+            new() { Id = Guid.NewGuid(), Name = "TPS", Description = "Third-person shooter", ParentId = actionGenre.Id },
+            new() { Id = Guid.NewGuid(), Name = "Beat 'em up", Description = "Fighting action games", ParentId = actionGenre.Id },
+            new() { Id = Guid.NewGuid(), Name = "Platformer", Description = "Platform jumping games", ParentId = actionGenre.Id },
+            new() { Id = Guid.NewGuid(), Name = "RTS", Description = "Real-time strategy", ParentId = strategyId },
+            new() { Id = Guid.NewGuid(), Name = "TBS", Description = "Turn-based strategy", ParentId = strategyId },
+            new() { Id = Guid.NewGuid(), Name = "4X", Description = "Explore, expand, exploit, exterminate", ParentId = strategyId },
+            new() { Id = Guid.NewGuid(), Name = "Tower Defense", Description = "Defensive strategy games", ParentId = strategyId },
+            new() { Id = Guid.NewGuid(), Name = "Football", Description = "American football games", ParentId = sportsId },
+            new() { Id = Guid.NewGuid(), Name = "Soccer", Description = "Association football games", ParentId = sportsId },
+            new() { Id = Guid.NewGuid(), Name = "Basketball", Description = "Basketball simulation games", ParentId = sportsId },
+            new() { Id = Guid.NewGuid(), Name = "Baseball", Description = "Baseball simulation games", ParentId = sportsId },
+            new() { Id = Guid.NewGuid(), Name = "JRPG", Description = "Japanese role-playing games", ParentId = rpgId },
+            new() { Id = Guid.NewGuid(), Name = "Action RPG", Description = "Action-oriented RPGs", ParentId = rpgId },
+            new() { Id = Guid.NewGuid(), Name = "Tactical RPG", Description = "Strategy-based RPGs", ParentId = rpgId },
+            new() { Id = Guid.NewGuid(), Name = "MMORPG", Description = "Massively multiplayer online RPGs", ParentId = rpgId },
+            new() { Id = Guid.NewGuid(), Name = "Formula", Description = "Formula racing games", ParentId = racingId },
+            new() { Id = Guid.NewGuid(), Name = "Rally", Description = "Rally racing games", ParentId = racingId },
+            new() { Id = Guid.NewGuid(), Name = "Arcade Racing", Description = "Arcade-style racing", ParentId = racingId },
+            new() { Id = Guid.NewGuid(), Name = "Off-road", Description = "Off-road racing games", ParentId = racingId }
         };
+    }
+    
+
+    public static DataAccess.Entities.Genre GenerateActionGenre()
+    {
+        return new() { Id = Guid.NewGuid(), Name = "Action", Description = "Fast-paced action games" };
+    }
+    
+    public static List<Guid> GenerateGenreChildren(Guid parentId)
+    {
+        var genres = GenerateGenreEntities();
+        var result  = new List<Guid> { parentId };
+        GetGenreChildrenRecursively(genres, parentId, result);
+        return result;
+    }
+
+    private static void GetGenreChildrenRecursively(List<DataAccess.Entities.Genre> genres, Guid parentId, List<Guid> result)
+    {
+        var children = genres.Where(g => g.ParentId == parentId);
+        foreach (var child in children)
+        {
+            result.Add(child.Id);
+            GetGenreChildrenRecursively(genres, child.Id, result);
+        }
     }
 }

--- a/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreControllerTests.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreControllerTests.cs
@@ -154,7 +154,7 @@ public class GenreControllerTests
     public async Task GetGamesByGenre_ShouldReturnNotFound_WhenGenreDoesNotExist()
     {
         // Arrange
-        _genreService.Setup(x => x.GetGamesByGenreAsync(It.IsAny<Guid>()))
+        _genreService.Setup(x => x.GetGames(It.IsAny<Guid>()))
             .ReturnsAsync(null as IEnumerable<GameResponseDto>);
         
         // Act
@@ -174,7 +174,7 @@ public class GenreControllerTests
         var games = TestData.Game.GenerateGameResponseDtos()
             .Where(game => game.Genres.Any(genre => children.Contains(genre.Id.Value))).ToList();
 
-        _genreService.Setup(x => x.GetGamesByGenreAsync(actionGenreId))
+        _genreService.Setup(x => x.GetGames(actionGenreId))
             .ReturnsAsync(games);
         
         // Act

--- a/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreServiceTests.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreServiceTests.cs
@@ -184,7 +184,7 @@ public class GenreServiceTests
         _gameRepository.Setup(x => x.GetByGenreAndItsChildrenAsync(children)).ReturnsAsync(games);
 
         // Act
-        var result = await _service.GetGamesByGenreAsync(actionGenreId);
+        var result = await _service.GetGames(actionGenreId);
         
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -201,7 +201,7 @@ public class GenreServiceTests
             .ReturnsAsync(false);
 
         // Act
-        var result = await _service.GetGamesByGenreAsync(Guid.NewGuid());
+        var result = await _service.GetGames(Guid.NewGuid());
         
         // Assert
         Assert.That(result, Is.Null);

--- a/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreServiceTests.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/Unit/Genre/GenreServiceTests.cs
@@ -1,7 +1,9 @@
 using Moq;
 using NUnit.Framework;
 using PracticeGamestore.Business.DataTransferObjects;
+using PracticeGamestore.Business.Mappers;
 using PracticeGamestore.Business.Services.Genre;
+using PracticeGamestore.DataAccess.Repositories.Game;
 using PracticeGamestore.DataAccess.Repositories.Genre;
 using PracticeGamestore.DataAccess.UnitOfWork;
 
@@ -9,29 +11,29 @@ namespace PracticeGamestore.Tests.Unit.Genre;
 
 public class GenreServiceTests
 {
-    private Mock<IGenreRepository> _genreRepositoryMock;
-    private Mock<IUnitOfWork> _unitOfWorkMock;
+    private Mock<IGenreRepository> _genreRepository;
+    private Mock<IUnitOfWork> _unitOfWork;
+    private Mock<IGameRepository> _gameRepository;
     private GenreService _service;
 
     [SetUp]
     public void Setup()
     {
-        _genreRepositoryMock = new Mock<IGenreRepository>();
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _service = new GenreService(_genreRepositoryMock.Object, _unitOfWorkMock.Object);
+        _genreRepository = new Mock<IGenreRepository>();
+        _unitOfWork = new Mock<IUnitOfWork>();
+        _gameRepository = new Mock<IGameRepository>();
+        _service = new GenreService(_genreRepository.Object, _gameRepository.Object, _unitOfWork.Object); // Correct order
     }
+    
+    
 
     [Test]
     public async Task GetAllAsync_ReturnsAllGenres()
     {
-        //Arrange
-        var entities = new List<DataAccess.Entities.Genre>
-        {
-            new() { Id = Guid.NewGuid(), Name = "Action" },
-            new() { Id = Guid.NewGuid(), Name = "FPS" },
-        };
+        // Arrange
+        var entities = TestData.Genre.GenerateGenreEntities();
         
-        _genreRepositoryMock.Setup(x => x.GetAllAsync()).ReturnsAsync(entities);
+        _genreRepository.Setup(x => x.GetAllAsync()).ReturnsAsync(entities);
         
         // Act
         var result = (await _service.GetAllAsync()).ToList();
@@ -45,10 +47,10 @@ public class GenreServiceTests
     [Test]
     public async Task GetByIdAsync_WhenGenreExists_ReturnsGenreDto()
     {
-        //Arrange
-        var entity = new DataAccess.Entities.Genre { Id = Guid.NewGuid(), Name = "Strategy" };
+        // Arrange
+        var entity = TestData.Genre.GenerateActionGenre();
         
-        _genreRepositoryMock.Setup(x => x.GetByIdAsync(entity.Id)).ReturnsAsync(entity);
+        _genreRepository.Setup(x => x.GetByIdAsync(entity.Id)).ReturnsAsync(entity);
         
         // Act
         var result = await _service.GetByIdAsync(entity.Id);
@@ -62,8 +64,8 @@ public class GenreServiceTests
     [Test]
     public async Task GetByIdAsync_WhenGenreDoesNotExist_ReturnsNull()
     {
-        //Arrange
-        _genreRepositoryMock
+        // Arrange
+        _genreRepository
             .Setup(x => x.GetByIdAsync(It.IsAny<Guid>()))
             .ReturnsAsync(null as DataAccess.Entities.Genre);
         
@@ -77,13 +79,13 @@ public class GenreServiceTests
     [Test]
     public async Task CreateAsync_WhenChangesSavedSuccessfully_ReturnsCreatedId()
     {
-        //Arrange
+        // Arrange
         var dto = new GenreDto(Guid.NewGuid(), "Action");
         
-        _genreRepositoryMock
+        _genreRepository
             .Setup(x => x.CreateAsync(It.IsAny<DataAccess.Entities.Genre>()))
             .ReturnsAsync(dto.Id!.Value);
-        _unitOfWorkMock
+        _unitOfWork
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
         
@@ -97,13 +99,13 @@ public class GenreServiceTests
     [Test]
     public async Task CreateAsync_WhenSaveChangesFailed_ReturnsNull()
     {
-        //Arrange
+        // Arrange
         var dto = new GenreDto(Guid.NewGuid(), "Action");
         
-        _genreRepositoryMock
+        _genreRepository
             .Setup(x => x.CreateAsync(It.IsAny<DataAccess.Entities.Genre>()))
             .ReturnsAsync(dto.Id!.Value);
-        _unitOfWorkMock
+        _unitOfWork
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
         
@@ -117,15 +119,15 @@ public class GenreServiceTests
     [Test]
     public async Task UpdateAsync_WhenEntityExistsAndChangesSavedSuccessfully_ReturnsTrue()
     {
-        //Arrange
+        // Arrange
         var id = Guid.NewGuid();
         var dto = new GenreDto(id, "Action");
         var entity = new DataAccess.Entities.Genre { Id = id, Name = "Action" };
         
-        _genreRepositoryMock
+        _genreRepository
             .Setup(x => x.GetByIdAsync(entity.Id))
             .ReturnsAsync(entity);
-        _unitOfWorkMock
+        _unitOfWork
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
         
@@ -139,11 +141,11 @@ public class GenreServiceTests
     [Test]
     public async Task UpdateAsync_WhenEntityDoesNotExist_ReturnsFalse()
     {
-        //Arrange
+        // Arrange
         var id = Guid.NewGuid();
         var dto = new GenreDto(id, "Action");
         
-        _genreRepositoryMock
+        _genreRepository
             .Setup(x => x.GetByIdAsync(It.IsAny<Guid>()))
             .ReturnsAsync(null as DataAccess.Entities.Genre);
         
@@ -157,14 +159,51 @@ public class GenreServiceTests
     [Test]
     public async Task DeleteAsync_CallsDeleteAndSaveChanges()
     {
-        //Arrange
+        // Arrange
         var id = Guid.NewGuid();
         
         // Act
         await _service.DeleteAsync(id);
          
         // Assert
-        _genreRepositoryMock.Verify(x => x.DeleteAsync(id), Times.Once);
-        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _genreRepository.Verify(x => x.DeleteAsync(id), Times.Once);
+        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+    
+    [Test]
+    public async Task GetGamesByGenreAsync_ReturnsGamesWithinProvidedGenreAndAllItsChildrenGenres()
+    {
+        // Arrange
+        var actionGenreId = TestData.Genre.GenerateActionGenre().Id;
+        var children = TestData.Genre.GenerateGenreChildren(actionGenreId);
+        
+        var games = TestData.Game.GenerateGameEntities()
+            .Where(game => game.GameGenres.Any(gg => children.Contains(gg.GenreId))).ToList();
+        _genreRepository.Setup(x => x.ExistsAsync(actionGenreId)).ReturnsAsync(true);
+        _genreRepository.Setup(x => x.GetGenreChildrenIdsAsync(actionGenreId)).ReturnsAsync(children);
+        _gameRepository.Setup(x => x.GetByGenreAndItsChildrenAsync(children)).ReturnsAsync(games);
+
+        // Act
+        var result = await _service.GetGamesByGenreAsync(actionGenreId);
+        
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        var gameResponseDtos = result!.ToList();
+        Assert.That(gameResponseDtos.Count, Is.EqualTo(games.Count));
+        Assert.That(gameResponseDtos.All(g => g.Genres.Any(genre => children.Contains(genre.Id.Value))), Is.True);
+    }
+    
+    [Test]
+    public async Task GetGamesByGenreAsync_ReturnsNullIfSuchGenreDoesNotExist()
+    {
+        // Arrange
+        _genreRepository.Setup(x => x.ExistsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _service.GetGamesByGenreAsync(Guid.NewGuid());
+        
+        // Assert
+        Assert.That(result, Is.Null);
     }
 }

--- a/PracticeGamestore/PracticeGamestore.Tests/Unit/Publisher/PublisherControllerTests.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/Unit/Publisher/PublisherControllerTests.cs
@@ -190,8 +190,7 @@ public class PublisherControllerTests
     {
         //Arrange
         var publisherId = Guid.NewGuid();
-        var publisher = TestData.Publisher.GeneratePublisherDto();
-        var games = TestData.Game.GenerateGameResponseDtos().Where(g => g.Publisher.Id == publisher.Id).ToList();
+        var games = TestData.Game.GenerateGameResponseDtos().Where(g => g.Publisher.Id == publisherId).ToList();
         _publisherService.Setup(x => x.GetGamesAsync(publisherId))
             .ReturnsAsync(games);
 

--- a/PracticeGamestore/PracticeGamestore.Tests/Unit/Publisher/PublisherServiceTests.cs
+++ b/PracticeGamestore/PracticeGamestore.Tests/Unit/Publisher/PublisherServiceTests.cs
@@ -173,33 +173,32 @@ public class PublisherServiceTests
     public async Task GetGamesAsync_ShouldReturnPublisherGames_WhenPublisherExist()
     {
         //Arrange
-        var publisher = TestData.Publisher.GeneratePublisherEntity();
-        var games = TestData.Game.GenerateGameEntities().Where(g => g.PublisherId == publisher.Id).ToList();
-        _publisherRepository.Setup(x => x.GetByIdAsync(publisher.Id))
-            .ReturnsAsync(publisher);
-        _gameRepository.Setup(x => x.GetByPublisherIdAsync(publisher.Id))
+        var publisherId = Guid.NewGuid();
+        var games = TestData.Game.GenerateGameEntities().Where(g => g.PublisherId == publisherId).ToList();
+        _publisherRepository.Setup(x => x.ExistsAsync(publisherId))
+            .ReturnsAsync(true);
+        _gameRepository.Setup(x => x.GetByPublisherIdAsync(publisherId))
             .ReturnsAsync(games);
         
         //Act
-        var result = await _publisherService.GetGamesAsync(publisher.Id);
+        var result = await _publisherService.GetGamesAsync(publisherId);
         
         //Assert
         Assert.That(result, Is.Not.Null);
         var gameResponseDtos = result!.ToList();
         Assert.That(gameResponseDtos.Count, Is.EqualTo(games.Count));
-        Assert.That(gameResponseDtos.All(dto => dto.Publisher.Id == publisher.Id), Is.True);
+        Assert.That(gameResponseDtos.All(dto => dto.Publisher.Id == publisherId), Is.True);
     }
     
     [Test]
     public async Task GetGamesAsync_ShouldReturnNull_WhenPublisherDoesNotExist()
     {
         //Arrange
-        var publisher = TestData.Publisher.GeneratePublisherEntity();
-        _publisherRepository.Setup(x => x.GetByIdAsync(publisher.Id))
-            .ReturnsAsync(null as DataAccess.Entities.Publisher); 
+        _publisherRepository.Setup(x => x.ExistsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(false); 
         
         //Act
-        var result = await _publisherService.GetGamesAsync(publisher.Id);
+        var result = await _publisherService.GetGamesAsync(Guid.NewGuid());
         
         //Assert
         Assert.That(result, Is.Null);


### PR DESCRIPTION
Created a new `Get endpoint /genre/{genreId}/games.`
Implemented required tests. Additionally, modified publisher service to only check for the existence of a publisher by the provided ID instead of getting a whole entity in the `GetGamesAsync `method (made all related changes).



